### PR TITLE
Rethink player order functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /a.xml
 /anime.xml
 /lite_db.store
+/player_order.store
 /search.xml

--- a/lib/player_order.rb
+++ b/lib/player_order.rb
@@ -1,27 +1,16 @@
-class PlayerOrder
-  def initialize
-    @buffer = []
-  end
+# Poor man's ring buffer
 
-  def mark(player)
-    player_position = @buffer.index(player)
-    @buffer = @buffer[0, player_position] if player_position
-    @buffer.unshift(player)
-    self
+class PlayerOrder
+  def initialize(order)
+    @buffer = order
   end
 
   def advance
-    player = @buffer.pop
-    @buffer.unshift(player)
-    self
+    new_order = @buffer[1..-1] << next_player
+    self.class.new(new_order)
   end
 
   def next_player
-    @buffer.last
+    @buffer.first
   end
-
-  def to_ary
-    @buffer
-  end
-  alias to_a to_ary
 end

--- a/lib/player_order_store.rb
+++ b/lib/player_order_store.rb
@@ -1,0 +1,29 @@
+require "forwardable"
+require "singleton"
+require "yaml"
+require "yaml/store"
+
+class PlayerOrderStore
+  include Singleton
+
+  class << self
+    extend Forwardable
+    def_delegators :instance, :get, :set
+  end
+
+  def initialize
+    @db = YAML::Store.new "player_order.store"
+  end
+
+  def get(channel:)
+    @db.transaction do
+      @db[channel.id]
+    end
+  end
+
+  def set(channel:, value:)
+    @db.transaction do
+      @db[channel.id] = value
+    end
+  end
+end

--- a/spec/player_order_spec.rb
+++ b/spec/player_order_spec.rb
@@ -1,75 +1,25 @@
 require "player_order"
 
 describe PlayerOrder do
-  subject(:order) { described_class.new }
+  subject(:order) { described_class.new([:a, :b, :c, :d]) }
 
-  it "marks the first player to take a turn" do
-    expect(
-      order.mark("first").to_ary
-    ).to eq(
-      ["first"]
-    )
+  it "returns the first player" do
+    expect(order.next_player).to eq(:a)
   end
 
-  it "marks the second player to take a turn" do
-    expect(
-      order.mark("first").mark("second").to_ary
-    ).to eq(
-      ["second", "first"]
-    )
+  it "returns the second player" do
+    expect(order.advance.next_player).to eq(:b)
   end
 
-  it "marks the first repeating player to take a turn" do
-    expect(
-      order.mark("first").mark("second").mark("third").mark("first").to_ary
-    ).to eq(
-      ["first", "third", "second"]
-    )
+  it "returns the third player" do
+    expect(order.advance.advance.next_player).to eq(:c)
   end
 
-  it "marks the second repeating player to take a turn" do
-    expect(
-      order
-        .mark("first").mark("second").mark("third")
-        .mark("first").mark("second")
-        .to_ary
-    ).to eq(
-      ["second", "first", "third"]
-    )
+  it "returns the fourth player" do
+    expect(order.advance.advance.advance.next_player).to eq(:d)
   end
 
-  it "advances to the next turn" do
-    expect(
-      order
-        .mark("first").mark("second").mark("third")
-        .mark("first").mark("second")
-        .advance
-        .to_ary
-    ).to eq(
-      ["third", "second", "first"]
-    )
-  end
-
-  it "reports whose turn it is next", :aggregate_failures do
-    # Stat with 3 players
-    expect(
-      order
-      .mark("first").mark("second").mark("third").mark("first")
-        .next_player
-    ).to eq("second")
-
-    # Continue with 4 players
-    expect(
-      order
-      .mark("first").mark("second").mark("third").mark("fourth").mark("first")
-        .next_player
-    ).to eq("second")
-
-    # Drop down to 2 players
-    expect(
-      order
-        .mark("first").mark("second").mark("first")
-        .next_player
-    ).to eq("second")
+  it "returns the first player again" do
+    expect(order.advance.advance.advance.advance.next_player).to eq(:a)
   end
 end


### PR DESCRIPTION
Now needs an explicit initialization step:

    board init @player1 @player2 ...

After that ping the next player:

    board next